### PR TITLE
Ch4 L3 - Convert MD document into HTML Blocks

### DIFF
--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -17,6 +17,8 @@ def markdown_to_html_node(doc):
         html_node = None;
         match (block_type):
             case BlockType.PARAGRAPH:
+                #remove newlines from this block type
+                block = " ".join(block.split("\n"))
                 text_nodes = text_to_nodes(block)
                 block_html_children = text_to_children(text_nodes)
                 html_node = ParentNode("p", block_html_children)
@@ -26,12 +28,13 @@ def markdown_to_html_node(doc):
                     hnum += 1
                     if block[hnum] != "#":
                         break
-                }
                 text_nodes = text_to_nodes(block[hnum:len(block)].strip())
                 block_html_children = text_to_children(text_nodes)
                 html_node = ParentNode(f"h{hnum}", block_html_children)
             case BlockType.CODE:
                 # wrap with <pre></pre> and treat block as one long text node without the wrapping ```...``` ie. do not add inner html
+                # should remove leading and trailing \n 
+                stripped_block = block[3:len(block)-3].strip()
                 html_node = ParentNode("pre", [LeafNode("code", block[3:len(block)-3])])
             case BlockType.QUOTE:
                 #remove all > characters that follow a newline
@@ -42,7 +45,7 @@ def markdown_to_html_node(doc):
                 text_nodes = text_to_nodes(formatted_block)
                 block_html_children = text_to_children(text_nodes)
                 html_node = ParentNode("blockquote", block_html_children)
-            case ORDERED_LIST:
+            case BlockType.ORDERED_LIST:
                 #remove all - characters
                 split_block = re.split("\n[1-9][0-9]*[.]", block[2:len(block)])
                 #create parent nodes out of each of these splits
@@ -50,7 +53,7 @@ def markdown_to_html_node(doc):
                 for split in split_block:
                     ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split))))
                 html_node = ParentNode("ol", ol_children)
-            case UNORDERED_LIST:
+            case BlockType.UNORDERED_LIST:
                 #remove all - characters
                 split_block = re.split("\n-", block[1:len(block)])
                 #create parent nodes out of each of these splits
@@ -65,7 +68,7 @@ def markdown_to_html_node(doc):
 
 
 #Takes a list of text nodes and converts them into html leaf nodes
-def text_to_children(text_nodes)
+def text_to_children(text_nodes):
     leaf_html_nodes = []
     for text_node in text_nodes:
         leaf_html_nodes.append(text_node_to_html_node(text_node))

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -54,7 +54,7 @@ def markdown_to_html_node(doc):
                 #create parent nodes out of each of these splits
                 ol_children = []
                 for split in split_block:
-                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split))))
+                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split.strip()))))
                 html_node = ParentNode("ol", ol_children)
             case BlockType.UNORDERED_LIST:
                 #remove all - characters
@@ -62,7 +62,7 @@ def markdown_to_html_node(doc):
                 #create parent nodes out of each of these splits
                 ol_children = []
                 for split in split_block:
-                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split))))
+                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split.strip()))))
                 html_node = ParentNode("ul", ol_children)
             case _:
                 printf(f"unsupported case {block_type}")

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -1,0 +1,18 @@
+from splitnodes import split_doc_to_blocks 
+from blockconverter import block_to_block_type
+from htmlnode import HTMLNode, LeafNode, ParentNode        
+from textnode import TextType
+        
+
+# converts an md text document into an html text document wrapped in <div></div> tags.
+def markdown_to_html_node(doc):
+    #todo, put this in its own file
+    blocks = split_doc_to_blocks(doc)
+    for block in blocks:
+        #determine type
+        block_type = block_to_block_type(block);
+        block_node = None;
+        match (block_type):
+            case TextType.TEXT:
+                block_node = HTMLNode("p", block, None, None )#todo implement adding children
+ 

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -1,8 +1,9 @@
-from splitnodes import split_doc_to_blocks 
+from splitnodes import split_doc_to_blocks, text_to_nodes
 from blockconverter import block_to_block_type
-from htmlnode import HTMLNode, LeafNode, ParentNode        
+from textconverter import text_node_to_html_node
+from htmlnode import HTMLNode, LeafNode, ParentNode
 from textnode import TextType
-        
+
 
 # converts an md text document into an html text document wrapped in <div></div> tags.
 def markdown_to_html_node(doc):
@@ -14,5 +15,42 @@ def markdown_to_html_node(doc):
         block_node = None;
         match (block_type):
             case TextType.TEXT:
-                block_node = HTMLNode("p", block, None, None )#todo implement adding children
- 
+                text_nodes = text_to_nodes(block)
+                block_html_children = text_to_children(text_nodes)
+                block_node = ParentNode("p", block_html_children)
+                break
+            case TextType.HEADING:
+                # TODO: special handling:  count the number of "#" marks up to 6
+                hnum = 0;
+                while hnum < 7:
+                    hnum += 1
+                    if block[hnum] != "#":
+                        break
+                }
+                text_nodes = text_to_nodes(block[hnum:len(block)].strip())
+                block_html_children = text_to_children(text_nodes)
+                block_node = ParentNode(f"h{hnum}", block_html_children)
+                break
+            case TextType.CODE:
+                # TODO special handling:  wrap with <pre></pre> tags and treet block as one long text node without the wrapping ```...``` ie. do not add inner html
+                block_node = ParentNode("pre", [LeafNode("code", block[3:len(block)-3])])
+                break
+            case TextType.QUOTE:
+                #remove all > characters that follow a newline
+                split_block = block[1:len(block)]).split("\n>")
+                formatted_block = "\n".join(split_block)
+                text_nodes = text_to_nodes(formatted_block)
+                block_html_children = text_to_children(text_nodes)
+                
+                block_node = ParentNode("blockquote", block_html_children)
+                break
+
+
+
+#Takes a list of text nodes and converts them into html leaf nodes
+def text_to_children(text_nodes)
+    leaf_html_nodes = []
+    for text_node in text_nodes:
+        leaf_html_nodes.append(text_node_to_html_node(text_node))
+    return leaf_html_nodes
+        

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -33,9 +33,11 @@ def markdown_to_html_node(doc):
                 html_node = ParentNode(f"h{hnum}", block_html_children)
             case BlockType.CODE:
                 # wrap with <pre></pre> and treat block as one long text node without the wrapping ```...``` ie. do not add inner html
+                stripped_block = block[3:len(block)].strip()
                 # should remove leading and trailing \n 
-                stripped_block = block[3:len(block)-3].strip()
-                html_node = ParentNode("pre", [LeafNode("code", block[3:len(block)-3])])
+                stripped_block = re.sub("^(\n)+$", "", stripped_block)
+                stripped_block = re.sub("(\n)*```", "", stripped_block)
+                html_node = ParentNode("pre", [LeafNode("code", stripped_block)])
             case BlockType.QUOTE:
                 #remove all > characters that follow a newline
                 split_block = block[1:len(block)].split("\n>")

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -1,26 +1,26 @@
+import re
 from splitnodes import split_doc_to_blocks, text_to_nodes
 from blockconverter import block_to_block_type
 from textconverter import text_node_to_html_node
 from htmlnode import HTMLNode, LeafNode, ParentNode
-from textnode import TextType
+from blocktype import BlockType
 
 
 # converts an md text document into an html text document wrapped in <div></div> tags.
 def markdown_to_html_node(doc):
     #todo, put this in its own file
+    html_nodes = []
     blocks = split_doc_to_blocks(doc)
     for block in blocks:
         #determine type
         block_type = block_to_block_type(block);
-        block_node = None;
+        html_node = None;
         match (block_type):
-            case TextType.TEXT:
+            case BlockType.PARAGRAPH:
                 text_nodes = text_to_nodes(block)
                 block_html_children = text_to_children(text_nodes)
-                block_node = ParentNode("p", block_html_children)
-                break
-            case TextType.HEADING:
-                # TODO: special handling:  count the number of "#" marks up to 6
+                html_node = ParentNode("p", block_html_children)
+            case BlockType.HEADING:
                 hnum = 0;
                 while hnum < 7:
                     hnum += 1
@@ -29,22 +29,39 @@ def markdown_to_html_node(doc):
                 }
                 text_nodes = text_to_nodes(block[hnum:len(block)].strip())
                 block_html_children = text_to_children(text_nodes)
-                block_node = ParentNode(f"h{hnum}", block_html_children)
-                break
-            case TextType.CODE:
-                # TODO special handling:  wrap with <pre></pre> tags and treet block as one long text node without the wrapping ```...``` ie. do not add inner html
-                block_node = ParentNode("pre", [LeafNode("code", block[3:len(block)-3])])
-                break
-            case TextType.QUOTE:
+                html_node = ParentNode(f"h{hnum}", block_html_children)
+            case BlockType.CODE:
+                # wrap with <pre></pre> and treat block as one long text node without the wrapping ```...``` ie. do not add inner html
+                html_node = ParentNode("pre", [LeafNode("code", block[3:len(block)-3])])
+            case BlockType.QUOTE:
                 #remove all > characters that follow a newline
-                split_block = block[1:len(block)]).split("\n>")
+                split_block = block[1:len(block)].split("\n>")
+                #Replace the newline characters without the '>'
                 formatted_block = "\n".join(split_block)
+                #Now that the wrapping markdown is removed, we can conver the text into nodes
                 text_nodes = text_to_nodes(formatted_block)
                 block_html_children = text_to_children(text_nodes)
-                
-                block_node = ParentNode("blockquote", block_html_children)
-                break
-
+                html_node = ParentNode("blockquote", block_html_children)
+            case ORDERED_LIST:
+                #remove all - characters
+                split_block = re.split("\n[1-9][0-9]*[.]", block[2:len(block)])
+                #create parent nodes out of each of these splits
+                ol_children = []
+                for split in split_block:
+                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split))))
+                html_node = ParentNode("ol", ol_children)
+            case UNORDERED_LIST:
+                #remove all - characters
+                split_block = re.split("\n-", block[1:len(block)])
+                #create parent nodes out of each of these splits
+                ol_children = []
+                for split in split_block:
+                    ol_children.append(ParentNode('li', text_to_children(text_to_nodes(split))))
+                html_node = ParentNode("ul", ol_children)
+            case _:
+                printf(f"unsupported case {block_type}")
+        html_nodes.append(html_node)
+    return ParentNode("div", html_nodes)
 
 
 #Takes a list of text nodes and converts them into html leaf nodes

--- a/src/htmlconverter.py
+++ b/src/htmlconverter.py
@@ -42,6 +42,7 @@ def markdown_to_html_node(doc):
                 #remove all > characters that follow a newline
                 split_block = block[1:len(block)].split("\n>")
                 #Replace the newline characters without the '>'
+                split_block = strip_splits(split_block)
                 formatted_block = "\n".join(split_block)
                 #Now that the wrapping markdown is removed, we can conver the text into nodes
                 text_nodes = text_to_nodes(formatted_block)
@@ -69,7 +70,12 @@ def markdown_to_html_node(doc):
     return ParentNode("div", html_nodes)
 
 
-#Takes a list of text nodes and converts them into html leaf nodes
+def strip_splits(splits):
+    for split in range(len(splits)):
+        splits[split] = splits[split].strip()#Takes a list of text nodes and converts them into html leaf nodes
+    return splits
+
+
 def text_to_children(text_nodes):
     leaf_html_nodes = []
     for text_node in text_nodes:

--- a/src/splitnodes.py
+++ b/src/splitnodes.py
@@ -6,9 +6,15 @@ def split_doc_to_blocks(doc):
     blocks = doc.split("\n\n")
     final_blocks = []
     for block in blocks:
+        #If the block is empty, skip it to the next one
         if block.strip() == "":
             continue
-        block = block.strip()
+        #format each block line of the block so none have trailing whitespace
+        splits = block.split("\n")
+        f_splits = []
+        for split in splits:
+            f_splits.append( split.strip())
+        block = "\n".join(f_splits).strip()
         final_blocks.append(block)
     return final_blocks
 

--- a/src/test_htmlconverter.py
+++ b/src/test_htmlconverter.py
@@ -34,4 +34,18 @@ the **same** even with inline stuff
             "<div><pre><code>This is text that _should_ remain\nthe **same** even with inline stuff</code></pre></div>",
         )
 
+    def test_quote(self):
+        md = """> This is a _quote_
+        > There are many like it but this one is mine
+        > Without me, my quote is nothing
+        > Without my quote, **I** am nothing"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+
+        self.assertEqual(
+            html,
+            "<div><blockquote>This is a <i>quote</i>\nThere are many like it but this one is mine\nWithout me, my quote is nothing\nWithout my quote, <b>I</b> am nothing</blockquote></div>"
+        )
+
 

--- a/src/test_htmlconverter.py
+++ b/src/test_htmlconverter.py
@@ -39,13 +39,43 @@ the **same** even with inline stuff
         > There are many like it but this one is mine
         > Without me, my quote is nothing
         > Without my quote, **I** am nothing"""
-
         node = markdown_to_html_node(md)
         html = node.to_html()
-
         self.assertEqual(
             html,
             "<div><blockquote>This is a <i>quote</i>\nThere are many like it but this one is mine\nWithout me, my quote is nothing\nWithout my quote, <b>I</b> am nothing</blockquote></div>"
         )
+
+
+    def test_unordered_list(self):
+        md = """- This is an _unordered list_
+        - There are many like it but this one is mine
+        - Without me, my unordered list is nothing
+        - Without my unordered list, **I** am nothing"""
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><ul><li>This is an <i>unordered list</i></li><li>There are many like it but this one is mine</li><li>Without me, my unordered list is nothing</li><li>Without my unordered list, <b>I</b> am nothing</li></ul></div>"
+        )
+
+
+    def test_ordered_list(self):
+        md = """1. This is an _ordered list_
+        2. There are many like it but this one is mine
+        3. Without me, my ordered list is nothing
+        4. Without my ordered list, **I** am nothing"""
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><ol><li>This is an <i>ordered list</i></li><li>There are many like it but this one is mine</li><li>Without me, my ordered list is nothing</li><li>Without my ordered list, <b>I</b> am nothing</li></ol></div>"
+        )
+
+
+
+
+
+
 
 

--- a/src/test_htmlconverter.py
+++ b/src/test_htmlconverter.py
@@ -21,18 +21,17 @@ class TestHTMLConverter(unittest.TestCase):
         )
 
     def test_codeblock(self):
-        md = """
-```
+        md = """```
 This is text that _should_ remain
 the **same** even with inline stuff
-```
-"""
+```"""
 
         node = markdown_to_html_node(md)
         html = node.to_html()
+        #print(f"mine: {html}")
         self.assertEqual(
             html,
-            "<div><pre><code>This is text that _should_ remain\nthe **same** even with inline stuff\n</code></pre></div>",
+            "<div><pre><code>This is text that _should_ remain\nthe **same** even with inline stuff</code></pre></div>",
         )
 
 

--- a/src/test_htmlconverter.py
+++ b/src/test_htmlconverter.py
@@ -1,0 +1,38 @@
+from htmlconverter import markdown_to_html_node
+import unittest
+
+class TestHTMLConverter(unittest.TestCase):
+
+    def test_paragraphs(self):
+        md = """
+                This is **bolded** paragraph
+                text in a p
+                tag here
+
+                This is another paragraph with _italic_ text and `code` here
+
+                """
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><p>This is <b>bolded</b> paragraph text in a p tag here</p><p>This is another paragraph with <i>italic</i> text and <code>code</code> here</p></div>",
+        )
+
+    def test_codeblock(self):
+        md = """
+```
+This is text that _should_ remain
+the **same** even with inline stuff
+```
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><pre><code>This is text that _should_ remain\nthe **same** even with inline stuff\n</code></pre></div>",
+        )
+
+

--- a/src/test_htmlnode.py
+++ b/src/test_htmlnode.py
@@ -33,19 +33,6 @@ class TestHTMLNode(unittest.TestCase):
         parent_node = ParentNode("div", [child_node])
         self.assertEqual(parent_node.to_html(), "<div><span>child</span></div>")
 
-    def test_to_html_with_grandchildren(self):
-        grandchild_node = LeafNode("b", "grandchild")
-        child_node = ParentNode("span", [grandchild_node])
-        parent_node = ParentNode("div", [child_node])
-        self.assertEqual(
-            parent_node.to_html(),
-            "<div><span><b>grandchild</b></span></div>",
-        )
-
-    def test_to_html_with_children(self):
-        child_node = LeafNode("span", "child")
-        parent_node = ParentNode("div", [child_node])
-        self.assertEqual(parent_node.to_html(), "<div><span>child</span></div>")
 
     def test_to_html_with_grandchildren(self):
         grandchild_node = LeafNode("b", "grandchild")

--- a/src/textconverter.py
+++ b/src/textconverter.py
@@ -5,6 +5,7 @@ def text_node_to_html_node(text_node):
     if text_node is None:
         raise ValueError("Expected TextType but was None")
     match text_node.text_type:
+        #text nodes have no tag, we rely on htmlconverter t
         case TextType.TEXT:
             return LeafNode(None, text_node.text)
         case TextType.BOLD:

--- a/src/textnode.py
+++ b/src/textnode.py
@@ -26,12 +26,3 @@ class TextNode:
     def __repr__(self):
         return f"TextNode({self.text}, {self.text_type}, {self.url})"
 
-"""
-#Testing node creation
-test_node = TextNode("hello Jacob", TextType.TEXT, "http://word.com")
-print(test_node)
-
-#Testing TextNode eq comparison
-clone_node = TextNode("**I'm some bod text**", TextType.BOLD, "http://foo.com")
-print(test_node == clone_node)
-"""

--- a/test_htmlconverter.py
+++ b/test_htmlconverter.py
@@ -1,0 +1,38 @@
+from htmlconverter import markdown_to_html_node
+import unittest
+
+class TestHTMLConverter(unittest.TestCase):
+
+    def test_paragraphs(self):
+        md = """
+This is **bolded** paragraph
+text in a p
+tag here
+
+This is another paragraph with _italic_ text and `code` here
+
+"""
+
+        node = markdown_to_html_node(md)
+        html = node.to_html()
+        self.assertEqual(
+            html,
+            "<div><p>This is <b>bolded</b> paragraph text in a p tag here</p><p>This is another paragraph with <i>italic</i> text and <code>code</code> here</p></div>",
+        )
+
+def test_codeblock(self):
+    md = """
+```
+This is text that _should_ remain
+the **same** even with inline stuff
+```
+"""
+
+    node = markdown_to_html_node(md)
+    html = node.to_html()
+    self.assertEqual(
+        html,
+        "<div><pre><code>This is text that _should_ remain\nthe **same** even with inline stuff\n</code></pre></div>",
+    )
+
+


### PR DESCRIPTION
Implements `splitnodes.split_doc_to_blocks` and `htmlconverter.markdown_to_html_node` for transforming a document into markdown blocks and markdown blocks into html nodes.